### PR TITLE
fix: Use the correct syscall for process_vm_readv

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,12 +12,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Android (API 16, NDK 19)
+          - name: Android (API 16, NDK 20)
             ANDROID_API: 16
-            ANDROID_NDK: 19.2.5345600
-          - name: Android (API 30 NDK 21)
+            ANDROID_NDK: 20.1.5948944
+          - name: Android (API 30, NDK 22)
             ANDROID_API: 30
-            ANDROID_NDK: 21.3.6528147
+            ANDROID_NDK: 22.1.7171670
 
     runs-on: macos-latest
 

--- a/Memory.cpp
+++ b/Memory.cpp
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+#ifndef _GNU_SOURCE
+#    define _GNU_SOURCE 1
+#endif
 #include <errno.h>
 #include <fcntl.h>
 #include <stdint.h>
@@ -26,16 +29,6 @@
 #include <unistd.h>
 #include "unistdfix.h"
 #include <sys/syscall.h>
-#ifndef __NR_process_vm_readv
-#ifdef __i386__
-#define __NR_process_vm_readv 347
-#elif defined(__ILP32__)
-#define __X32_SYSCALL_BIT 0x40000000
-#define __NR_process_vm_readv (__X32_SYSCALL_BIT + 539)
-#else
-#define __NR_process_vm_readv 310
-#endif
-#endif
 
 #include <algorithm>
 #include <memory>
@@ -53,6 +46,19 @@
 #include "MemoryOfflineBuffer.h"
 #include "MemoryRange.h"
 #include "MemoryRemote.h"
+
+#ifdef __ANDROID_API__
+#    if __ANDROID_API__ < 23
+static ssize_t
+process_vm_readv(pid_t __pid, const struct iovec *__local_iov,
+    unsigned long __local_iov_count, const struct iovec *__remote_iov,
+    unsigned long __remote_iov_count, unsigned long __flags)
+{
+    return syscall(__NR_process_vm_readv, __pid, __local_iov, __local_iov_count,
+        __remote_iov, __remote_iov_count, __flags);
+}
+#    endif
+#endif
 
 namespace unwindstack {
 
@@ -103,7 +109,7 @@ static size_t ProcessVmRead(pid_t pid, uint64_t remote_src, void* dst, size_t le
       ++iovecs_used;
     }
 
-    ssize_t rc = syscall(__NR_process_vm_readv, pid, &dst_iov, 1, src_iovs, iovecs_used, 0);
+    ssize_t rc = process_vm_readv(pid, &dst_iov, 1, src_iovs, iovecs_used, 0);
     if (rc == -1) {
       return total_read;
     }
@@ -344,14 +350,7 @@ size_t MemoryRemote::Read(uint64_t addr, void* dst, size_t size) {
 }
 
 size_t MemoryLocal::Read(uint64_t addr, void* dst, size_t size) {
-  // Prefer process_vm_read, try it first. If it doesn't work, use direct
-  // memory read.
-  size_t result = ProcessVmRead(getpid(), addr, dst, size);
-  if (!result && size) {
-    memcpy(dst, (void *)addr, size);
-    result = size;
-  }
-  return result;
+  return ProcessVmRead(getpid(), addr, dst, size);
 }
 
 MemoryRange::MemoryRange(const std::shared_ptr<Memory>& memory, uint64_t begin, uint64_t length,

--- a/Memory.cpp
+++ b/Memory.cpp
@@ -47,8 +47,7 @@
 #include "MemoryRange.h"
 #include "MemoryRemote.h"
 
-#ifdef __ANDROID_API__
-#    if __ANDROID_API__ < 23
+#if defined(__ANDROID_API__) && __ANDROID_API__ < 23
 static ssize_t
 process_vm_readv(pid_t __pid, const struct iovec *__local_iov,
     unsigned long __local_iov_count, const struct iovec *__remote_iov,
@@ -57,7 +56,6 @@ process_vm_readv(pid_t __pid, const struct iovec *__local_iov,
     return syscall(__NR_process_vm_readv, __pid, __local_iov, __local_iov_count,
         __remote_iov, __remote_iov_count, __flags);
 }
-#    endif
 #endif
 
 namespace unwindstack {
@@ -354,7 +352,7 @@ size_t MemoryLocal::Read(uint64_t addr, void* dst, size_t size) {
     size_t rv = ProcessVmRead(getpid(), addr, dst, size);
     // The syscall is only available in Linux 3.2, meaning Android 17.
     // If that is the case, just fall back to an unsafe memcpy.
-#if __ANDROID_API__ < 17
+#if defined(__ANDROID_API__) && __ANDROID_API__ < 17
     if (rv != size && errno == EINVAL) {
         memcpy(dst, (void*)addr, size);
         rv = size;

--- a/Unwinder.cpp
+++ b/Unwinder.cpp
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-#define _GNU_SOURCE 1
+#ifndef _GNU_SOURCE
+#    define _GNU_SOURCE 1
+#endif
 #include <elf.h>
 #include <inttypes.h>
 #include <stdint.h>


### PR DESCRIPTION
It seems that some code added in https://github.com/ivanarh/libunwindstack-ndk/commit/af11b0c09a5888740ba085b1f59384afd2095e1d#diff-3110c28650da71aad0da90c7564871442ba3651cdb2e3eed5f14b85007568c97R295 and https://github.com/getsentry/libunwindstack-ndk/commit/453f55dd28773233cfc6ba3ede5e4e98d0c542a6#diff-3110c28650da71aad0da90c7564871442ba3651cdb2e3eed5f14b85007568c97R27 was wrong and the calls to `process_vm_readv` were incorrect, and the code retried using a straight memcpy, which possibly lead to some segfaults.

The new changes use the exported function directly on newer Android releases, and create a functioning wrapper for older Android versions.