### PR TITLE
fix: disable warning ndk build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           submodules: "recursive"
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407
         with:
-          packages: 'sdkmanager tools platform-tools'
+          packages: 'tools platform-tools'
 
       - name: Installing Android SDK Dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Installing Android SDK Dependencies
         run: |
           echo "Downloading ndk;$ANDROID_NDK"
-          echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install \
+          echo "y" | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install \
             "ndk;$ANDROID_NDK" | \
             grep -v "\[=" || true # suppress the progress bar, so we get meaningful logs
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,16 +19,27 @@ jobs:
             ANDROID_API: 30
             ANDROID_NDK: 22.1.7171670
 
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     env:
       ANDROID_API: ${{ matrix.ANDROID_API }}
       ANDROID_NDK: ${{ matrix.ANDROID_NDK }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: "recursive"
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407
+        with:
+          packages: 'sdkmanager tools platform-tools'
 
       - name: Installing Android SDK Dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,9 @@ jobs:
           - name: Android (API 16, NDK 20)
             ANDROID_API: 16
             ANDROID_NDK: 20.1.5948944
-          - name: Android (API 30, NDK 22)
-            ANDROID_API: 30
-            ANDROID_NDK: 22.1.7171670
+          - name: Android (API 35, NDK 27)
+            ANDROID_API: 35
+            ANDROID_NDK: 27.0.12077973
 
     runs-on: ubuntu-latest
 
@@ -48,12 +48,30 @@ jobs:
             "ndk;$ANDROID_NDK" | \
             grep -v "\[=" || true # suppress the progress bar, so we get meaningful logs
 
+      - name: Build x86
+        run: |
+          rm -rf build
+          cmake -B build -S cmake \
+            -D CMAKE_TOOLCHAIN_FILE=$ANDROID_HOME/ndk/$ANDROID_NDK/build/cmake/android.toolchain.cmake \
+            -D ANDROID_NATIVE_API_LEVEL=$ANDROID_API \
+            -D ANDROID_ABI=x86
+          cmake --build build --parallel
+
       - name: Build x86_64
         run: |
           cmake -B build -S cmake \
             -D CMAKE_TOOLCHAIN_FILE=$ANDROID_HOME/ndk/$ANDROID_NDK/build/cmake/android.toolchain.cmake \
             -D ANDROID_NATIVE_API_LEVEL=$ANDROID_API \
             -D ANDROID_ABI=x86_64
+          cmake --build build --parallel
+
+      - name: Build armeabi-v7a
+        run: |
+          rm -rf build
+          cmake -B build -S cmake \
+            -D CMAKE_TOOLCHAIN_FILE=$ANDROID_HOME/ndk/$ANDROID_NDK/build/cmake/android.toolchain.cmake \
+            -D ANDROID_NATIVE_API_LEVEL=$ANDROID_API \
+            -D ANDROID_ABI=armeabi-v7a
           cmake --build build --parallel
 
       - name: Build arm64-v8a

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -97,6 +97,7 @@ add_library(unwindstack STATIC
 )
 target_link_libraries(unwindstack log)
 set_property(TARGET unwindstack PROPERTY CXX_STANDARD 17)
+target_compile_options(unwindstack PRIVATE -Wno-c99-designator -Wno-reorder-init-list)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     target_compile_options(unwindstack PRIVATE $<BUILD_INTERFACE:-Wno-unknown-attributes>)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -97,7 +97,7 @@ add_library(unwindstack STATIC
 )
 target_link_libraries(unwindstack log)
 set_property(TARGET unwindstack PROPERTY CXX_STANDARD 17)
-target_compile_options(unwindstack PRIVATE -Wno-c99-designator -Wno-reorder-init-list)
+target_compile_options(unwindstack PRIVATE -Wunknown-warning-option -Wno-c99-designator -Wno-reorder-init-list)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     target_compile_options(unwindstack PRIVATE $<BUILD_INTERFACE:-Wno-unknown-attributes>)


### PR DESCRIPTION
fixes https://github.com/getsentry/sentry-native/issues/1085

In addition to ignoring the irrelevant warning, I also took the liberty to fix the GHA workflow:

* I increased the supported range to Android 35 and ndk 27 because that is what we should support downstream
* switched to Ubuntu from macOS because it is more available and typically runs faster (always use Ubuntu runners instead of macOS if that is an option)
* updated all action versions to a recent version
* using setup-java and setup-android actions so we can have a stable pre-config setup vs. relying on what the runner-image provides (which broke the initial run)
* switch to use `sdkmanager` from the`cmdline-tools` path because that is what the modern SDK path looks like
* adding additional ABI builds because we need to support them downstream 